### PR TITLE
Change external dependency to Googletest git repo

### DIFF
--- a/pcp-pmda-cpp.includes
+++ b/pcp-pmda-cpp.includes
@@ -1,7 +1,7 @@
-build/extern/src/googletest/include/gtest
-build/extern/src/googletest/include/gtest/internal
-build/extern/src/googletest/samples
-build/extern/src/googletest/src
-build/extern/src/googletest/test
-build/extern/src/googletest/xcode/Samples/FrameworkSample
+build/extern/src/googletest/googletest/include/gtest
+build/extern/src/googletest/googletest/include/gtest/internal
+build/extern/src/googletest/googletest/samples
+build/extern/src/googletest/googletest/src
+build/extern/src/googletest/googletest/test
+build/extern/src/googletest/googletest/xcode/Samples/FrameworkSample
 test/unit/src

--- a/test/unit/CMakeLists.txt
+++ b/test/unit/CMakeLists.txt
@@ -73,8 +73,8 @@ if (NOT GTEST_FOUND)
     add_dependencies(${PROJECT_NAME} googletest)
     # Mimic the FindGTest module's library variables.
     ExternalProject_Get_Property(googletest binary_dir)
-    set(GTEST_LIBRARY        ${binary_dir}/${CMAKE_FIND_LIBRARY_PREFIXES}gtest${CMAKE_STATIC_LIBRARY_SUFFIX})
-    set(GTEST_MAIN_LIBRARY   ${binary_dir}/${CMAKE_FIND_LIBRARY_PREFIXES}gtest_main${CMAKE_STATIC_LIBRARY_SUFFIX})
+    set(GTEST_LIBRARY        ${binary_dir}/googlemock/gtest/${CMAKE_FIND_LIBRARY_PREFIXES}gtest${CMAKE_STATIC_LIBRARY_SUFFIX})
+    set(GTEST_MAIN_LIBRARY   ${binary_dir}/googlemock/gtest/${CMAKE_FIND_LIBRARY_PREFIXES}gtest_main${CMAKE_STATIC_LIBRARY_SUFFIX})
     set(GTEST_BOTH_LIBRARIES ${GTEST_LIBRARY} ${GTEST_MAIN_LIBRARY})
 endif()
 

--- a/test/unit/GoogleTestExternal.cmake
+++ b/test/unit/GoogleTestExternal.cmake
@@ -9,7 +9,7 @@ set_directory_properties(PROPERTIES EP_PREFIX ${CMAKE_BINARY_DIR}/extern)
 # Add gtest
 ExternalProject_Add(
     googletest
-    SVN_REPOSITORY https://googletest.googlecode.com/svn/trunk/
+    GIT_REPOSITORY https://github.com/google/googletest.git
     UPDATE_COMMAND "" # Don't update the svn checkout every time we build.
     TIMEOUT 10
     CMAKE_ARGS -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE}
@@ -22,7 +22,7 @@ ExternalProject_Add(
 
 # Add googletest headers to the include path.
 ExternalProject_Get_Property(googletest source_dir)
-include_directories(${source_dir}/include)
+include_directories(${source_dir}/googletest/include)
 
 # Add compiler flag for MSVC 2012
 if(MSVC_VERSION EQUAL 1700)


### PR DESCRIPTION
The Googletest svn repo seems to be gone so move to git.

Signed-off-by: Brad Hubbard <bhubbard@redhat.com>