### PR TITLE
Adjust for pcp-4.0.0 release and subsequent API changes

### DIFF
--- a/include/pcp-cpp/config.hpp
+++ b/include/pcp-cpp/config.hpp
@@ -1,4 +1,5 @@
 //            Copyright Paul Colby 2013 - 2015.
+//            Copyright Red Hat 2018.
 // Distributed under the Boost Software License, Version 1.0.
 //       (See accompanying file LICENSE.md or copy at
 //          http://www.boost.org/LICENSE_1_0.txt)
@@ -50,6 +51,19 @@
 #include <pcp/pmapi.h> // Note, the order in which these are included matters
 #include <pcp/impl.h>  // more for older versions of PCP, so don't reorder them
 #include <pcp/pmda.h>  // without testing against older versions of PCP.
+
+#ifndef PM_TEXT_PMID
+#define PM_TEXT_PMID	4
+#define PM_TEXT_INDOM	8
+#define PM_TEXT_DIRECT	16
+#endif
+
+#if PM_VERSION_CURRENT < PM_VERSION(4,0,0)
+#define pmID_cluster(pmid) pmid_cluster(pmid)
+#define pmID_item(pmid) pmid_item(pmid)
+#define pmPathSeparator __pmPathSeparator
+#define pmNotifyErr __pmNotifyErr
+#endif
 
 /// PMDA interface version to use; defaults to "latest".
 #ifndef PCP_CPP_PMDA_INTERFACE_VERSION

--- a/test/unit/CMakeLists.txt
+++ b/test/unit/CMakeLists.txt
@@ -88,6 +88,7 @@ target_link_libraries(
     ${Boost_PROGRAM_OPTIONS_LIBRARY}
     ${GTEST_BOTH_LIBRARIES}
     ${pthread}
+    pcp
 )
 
 # Add a custom "check-unit" target.

--- a/test/unit/src/fake_libpcp-pmda.cpp
+++ b/test/unit/src/fake_libpcp-pmda.cpp
@@ -1,4 +1,5 @@
 //               Copyright Paul Colby 2013.
+//               Copyright Red Hat 2018.
 // Distributed under the Boost Software License, Version 1.0.
 //       (See accompanying file LICENSE.md or copy at
 //          http://www.boost.org/LICENSE_1_0.txt)
@@ -103,7 +104,7 @@ void pmdaInit(pmdaInterface *dispatch, pmdaIndom *indoms,
 }
 
 int pmdaInstance(pmInDom /*indom*/, int /*inst*/, char */*name*/,
-                 __pmInResult **/*result*/, pmdaExt */*pmda*/)
+                 pmInResult **/*result*/, pmdaExt */*pmda*/)
 {
     return PM_ERR_NYI;
 }
@@ -123,7 +124,7 @@ int pmdaPMID(const char */*name*/, pmID */*pmid*/, pmdaExt */*pmda*/)
     return PM_ERR_NYI;
 }
 
-int pmdaProfile(__pmProfile */*prof*/, pmdaExt */*pmda*/)
+int pmdaProfile(pmProfile */*prof*/, pmdaExt */*pmda*/)
 {
     return PM_ERR_NYI;
 }

--- a/test/unit/src/fake_libpcp.cpp
+++ b/test/unit/src/fake_libpcp.cpp
@@ -1,4 +1,5 @@
 //               Copyright Paul Colby 2013-2014.
+//               Copyright Red Hat 2018.
 // Distributed under the Boost Software License, Version 1.0.
 //       (See accompanying file LICENSE.md or copy at
 //          http://www.boost.org/LICENSE_1_0.txt)
@@ -60,7 +61,7 @@ char *pmGetConfig(const char *variable)
     return (iter == fake_pm_config.end()) ? const_cast<char *>(variable) : iter->second;
 }
 
-void __pmNotifyErr(int /*priority*/, const char */*message*/, ...)
+void pmNotifyErr(int /*priority*/, const char */*message*/, ...)
 {
 
 }
@@ -85,14 +86,29 @@ int __pmParseDebug(const char *spec)
     return (result == -1) ? std::numeric_limits<int>::max() : result;
 }
 
-int __pmPathSeparator()
+int pmPathSeparator()
 {
     return '|';
 }
 
-void __pmSetProgname(const char */*program*/)
+void pmSetProgname(const char */*program*/)
 {
 
 }
 
+int pmSetDebug(const char *spec)
+{
+  if (spec == NULL) {
+        throw "spec must not be NULL";
+    }
+
+  if (strcmp(spec, "invalid") == 0) {
+    return PM_ERR_FAULT; // "QA fault injected"
+  }
+
+  if (strcmp(spec, "all") == 0) {
+      return std::numeric_limits<int>::max();
+  }
+  return 0;
+}
 } // extern "C"

--- a/test/unit/src/test_pmda.cpp
+++ b/test/unit/src/test_pmda.cpp
@@ -1,4 +1,5 @@
 //               Copyright Paul Colby 2013.
+//               Copyright Red Hat Inc. 2018.
 // Distributed under the Boost Software License, Version 1.0.
 //       (See accompanying file LICENSE.md or copy at
 //          http://www.boost.org/LICENSE_1_0.txt)
@@ -225,9 +226,8 @@ TEST(pmda, parse_command_line_default_debug_option) {
     pmdaInterface interface;
     interface.version.two.ext = new pmdaExt;
     boost::program_options::variables_map options;
-    pmDebug = 0;
     EXPECT_TRUE(pmda.parse_command_line(2, argv, interface, options));
-    EXPECT_EQ(std::numeric_limits<int>::max(), pmDebug);
+    EXPECT_EQ(std::numeric_limits<int>::max(), pmSetDebug("all"));
     delete interface.version.two.ext;
 }
 


### PR DESCRIPTION
simple.cpp: 
add extern __pmProcessRunTimes
__pmPathSeparator() -> pmPathSeparator()
__pmNotifyErr() -> pmNotifyErr()

config.hpp:
add additional conditional macros

pmda.hpp:
__pmPathSeparator() -> pmPathSeparator()
__pmNotifyErr() -> pmNotifyErr()
__pmSetProgname() -> pmSetProgname()
__pmParseDebug() -> pmSetDebug()
pmid_cluster() -> pmID_cluster()
pmid_item() -> pmID_item()
__pmProfile -> pmProfile
__pmInResult -> pmInResult

test/unit/CMakeLists.txt:
add libpcp to linkage list

fake_libpcp-pmda.cpp:
__pmInResult -> pmInResult
__pmProfile -> pmProfile

fake_libpcp.cpp:
__pmNotifyErr() -> pmNotifyErr()
__pmPathSeparator() -> pmPathSeparator()
__pmSetProgname() -> pmSetProgname()
add fake pmSetDebug() function
adjust parse_command_line_default_debug_option test